### PR TITLE
Use getPageLayout hook to collect page images

### DIFF
--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -27,6 +27,54 @@ class SocialImages extends \Controller
      */
     public function addSocialImages(\PageModel $objPage, \LayoutModel $objLayout, \PageRegular $objPageRegular)
     {
+        if (!is_array($GLOBALS['SOCIAL_IMAGES']) || empty($GLOBALS['SOCIAL_IMAGES']))
+        {
+            return;
+        }
+
+        $arrImages = array_unique($GLOBALS['SOCIAL_IMAGES']);
+
+        // Limit the images
+        if ($objLayout->socialImages_limit > 0)
+        {
+            $arrImages = array_slice($arrImages, 0, $objLayout->socialImages_limit);
+        }
+
+        $arrDimensions = deserialize($objLayout->socialImages_size, true);
+        $strHost = (\Environment::get('ssl') ? 'https://' : 'http://') . \Environment::get('host') . TL_PATH;
+
+        foreach ($arrImages as $strImage)
+        {
+            // Check the dimensions limit
+            if ($arrDimensions[0] > 0 && $arrDimensions[1] > 0)
+            {
+                list($width, $height) = getimagesize(TL_ROOT . '/' . $strImage);
+
+                if ($width < $arrDimensions[0] || $height < $arrDimensions[1])
+                {
+                    continue;
+                }
+            }
+
+            if ($objPage->outputFormat == 'xhtml')
+            {
+                $GLOBALS['TL_HEAD'][] = '<meta property="og:image" content="' . $strHost . '/' . $strImage . '" />';
+            }
+            else
+            {
+                $GLOBALS['TL_HEAD'][] = '<meta property="og:image" content="' . $strHost . '/' . $strImage . '">';
+            }
+        }
+    }
+
+
+    /**
+     * Collect the images from page
+     * @param object
+     * @param string
+     */
+    public function collectPageImages($objPage, $objLayout, $objPageRegular)
+    {
         if (!$objLayout->socialImages)
         {
             return;
@@ -68,45 +116,6 @@ class SocialImages extends \Controller
                         break;
                     }
                 }
-            }
-        }
-
-        if (!is_array($GLOBALS['SOCIAL_IMAGES']) || empty($GLOBALS['SOCIAL_IMAGES']))
-        {
-            return;
-        }
-
-        $arrImages = array_unique($GLOBALS['SOCIAL_IMAGES']);
-
-        // Limit the images
-        if ($objLayout->socialImages_limit > 0)
-        {
-            $arrImages = array_slice($arrImages, 0, $objLayout->socialImages_limit);
-        }
-
-        $arrDimensions = deserialize($objLayout->socialImages_size, true);
-        $strHost = (\Environment::get('ssl') ? 'https://' : 'http://') . \Environment::get('host') . TL_PATH;
-
-        foreach ($arrImages as $strImage)
-        {
-            // Check the dimensions limit
-            if ($arrDimensions[0] > 0 && $arrDimensions[1] > 0)
-            {
-                list($width, $height) = getimagesize(TL_ROOT . '/' . $strImage);
-
-                if ($width < $arrDimensions[0] || $height < $arrDimensions[1])
-                {
-                    continue;
-                }
-            }
-
-            if ($objPage->outputFormat == 'xhtml')
-            {
-                $GLOBALS['TL_HEAD'][] = '<meta property="og:image" content="' . $strHost . '/' . $strImage . '" />';
-            }
-            else
-            {
-                $GLOBALS['TL_HEAD'][] = '<meta property="og:image" content="' . $strHost . '/' . $strImage . '">';
             }
         }
     }

--- a/config/config.php
+++ b/config/config.php
@@ -32,3 +32,4 @@ $GLOBALS['TL_HOOKS']['getAllEvents'][] = array('SocialImages', 'collectEventImag
 $GLOBALS['TL_HOOKS']['getContentElement'][] = array('SocialImages', 'collectContentElementImages');
 $GLOBALS['TL_HOOKS']['generatePage'][] = array('SocialImages', 'addSocialImages');
 $GLOBALS['TL_HOOKS']['parseArticles'][] = array('SocialImages', 'collectNewsImages');
+$GLOBALS['TL_HOOKS']['getPageLayout'][] = array('SocialImages', 'collectPageImages');


### PR DESCRIPTION
I am planning to make the [sharebuttons](https://github.com/fritzmg/contao-sharebuttons) extension more "compatible" with the _social_images_ extension - more specifically, I would like to use the _social_images_ extension for providing the Pinterest (and WordPress) preview image via the social page image for example (See fritzmg/contao-sharebuttons#9).

This would require a small change of code in the _social_images_ extension. Currently the page image is only inserted into the `$GLOBALS['SOCIAL_IMAGES']` array via the `generatePage` hook. However, this hook is executed _after_ the regular content has been created - including the share buttons. Thus I cannot retrieve the social page image from within the share button elements and modules.

I propose to simply move this code
```php
if (!$objLayout->socialImages)
{
    return;
}

// Add the current page image
if ($objPage->socialImage && ($objImage = \FilesModel::findByUuid($objPage->socialImage)) !== null && is_file(TL_ROOT . '/' . $objImage->path))
{
    if (is_array($GLOBALS['SOCIAL_IMAGES']))
    {
        array_unshift($GLOBALS['SOCIAL_IMAGES'], $objImage->path);
    }
    else
    {
        $GLOBALS['SOCIAL_IMAGES'] = array($objImage->path);
    }
}
// Walk the trail
else
{
    $objTrail = \PageModel::findParentsById($objPage->id);

    if ($objTrail !== null)
    {
        while ($objTrail->next())
        {
            // Add the image
            if ($objTrail->socialImage && ($objImage = \FilesModel::findByUuid($objTrail->socialImage)) !== null && is_file(TL_ROOT . '/' . $objImage->path))
            {
                if (is_array($GLOBALS['SOCIAL_IMAGES']))
                {
                    array_unshift($GLOBALS['SOCIAL_IMAGES'], $objImage->path);
                }
                else
                {
                    $GLOBALS['SOCIAL_IMAGES'] = array($objImage->path);
                }

                break;
            }
        }
    }
}
```
to a new function `public function collectPageImages($objPage, $objLayout, $objPageRegular)` which is called via the `getPageLayout` hook. Everything else stays the same. This way, the `$GLOBALS['SOCIAL_IMAGES']` array is filled with the social page image before the regular content is created (and afterwards in the `generatePage` hook, the meta tags are inserted depending on the array contents as usual).