### PR TITLE
put news/event teaser image to the beginning of the array

### DIFF
--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -28,6 +28,8 @@ class SocialImages extends \Controller
         {
             $GLOBALS['SOCIAL_IMAGES'] = array();
         }
+
+        parent::__construct();
     }
 
 

--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -20,6 +20,18 @@ class SocialImages extends \Controller
 {
 
     /**
+     * Initializes the global array
+     */
+    public function __construct()
+    {
+        if (!isset($GLOBALS['SOCIAL_IMAGES']) || !is_array($GLOBALS['SOCIAL_IMAGES']))
+        {
+            $GLOBALS['SOCIAL_IMAGES'] = array();
+        }
+    }
+
+
+    /**
      * Add the social images to the page
      *
      * @param \PageModel   $objPage
@@ -27,7 +39,7 @@ class SocialImages extends \Controller
      */
     public function addSocialImages(\PageModel $objPage, \LayoutModel $objLayout)
     {
-        if (!is_array($GLOBALS['SOCIAL_IMAGES']) || empty($GLOBALS['SOCIAL_IMAGES']))
+        if (empty($GLOBALS['SOCIAL_IMAGES']))
         {
             return;
         }
@@ -83,14 +95,7 @@ class SocialImages extends \Controller
         // Add the current page image
         if ($objPage->socialImage && ($objImage = \FilesModel::findByUuid($objPage->socialImage)) !== null && is_file(TL_ROOT . '/' . $objImage->path))
         {
-            if (is_array($GLOBALS['SOCIAL_IMAGES']))
-            {
-                array_unshift($GLOBALS['SOCIAL_IMAGES'], $objImage->path);
-            }
-            else
-            {
-                $GLOBALS['SOCIAL_IMAGES'] = array($objImage->path);
-            }
+            array_unshift($GLOBALS['SOCIAL_IMAGES'], $objImage->path);
         }
         // Walk the trail
         else
@@ -104,14 +109,7 @@ class SocialImages extends \Controller
                     // Add the image
                     if ($objTrail->socialImage && ($objImage = \FilesModel::findByUuid($objTrail->socialImage)) !== null && is_file(TL_ROOT . '/' . $objImage->path))
                     {
-                        if (is_array($GLOBALS['SOCIAL_IMAGES']))
-                        {
-                            array_unshift($GLOBALS['SOCIAL_IMAGES'], $objImage->path);
-                        }
-                        else
-                        {
-                            $GLOBALS['SOCIAL_IMAGES'] = array($objImage->path);
-                        }
+                        array_unshift($GLOBALS['SOCIAL_IMAGES'], $objImage->path);
 
                         break;
                     }
@@ -346,7 +344,7 @@ class SocialImages extends \Controller
      * @param object
      * @param array
      */
-    public function collectNewsImages($objTemplate, $arrData)
+    public function collectNewsImages($objTemplate, $arrData, $objModule)
     {
         if (!$arrData['addImage'])
         {
@@ -357,7 +355,14 @@ class SocialImages extends \Controller
 
         if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
         {
-            array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
+            if ($objModule->type == 'newsreader')
+            {
+                array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
+            }
+            else
+            {
+                $GLOBALS['SOCIAL_IMAGES'][] = $objFile->path;
+            }
         }
     }
 
@@ -367,7 +372,7 @@ class SocialImages extends \Controller
      * @param array
      * @return array
      */
-    public function collectEventImages($arrEvents)
+    public function collectEventImages($arrEvents, $arrCalendars, $intStart, $intEnd, $objModule)
     {
         foreach ($arrEvents as $v)
         {
@@ -384,7 +389,14 @@ class SocialImages extends \Controller
 
                     if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
                     {
-                        array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
+                        if ($objModule->type == 'eventreader')
+                        {
+                            array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
+                        }
+                        else
+                        {
+                            $GLOBALS['SOCIAL_IMAGES'][] = $objFile->path;
+                        }
                     }
 
                 }

--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -357,7 +357,7 @@ class SocialImages extends \Controller
 
         if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
         {
-            $GLOBALS['SOCIAL_IMAGES'][] = $objFile->path;
+            array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
         }
     }
 
@@ -384,7 +384,7 @@ class SocialImages extends \Controller
 
                     if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
                     {
-                        $GLOBALS['SOCIAL_IMAGES'][] = $objFile->path;
+                        array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
                     }
 
                 }


### PR DESCRIPTION
Currently, the news and event teaser image is appended to the `$GLOBALS['SOCIAL_IMAGES']` array:

* https://github.com/codefog/contao-social_images/blob/3.2.0/classes/SocialImages.php#L360
* https://github.com/codefog/contao-social_images/blob/3.2.0/classes/SocialImages.php#L387

Consider sharing the following URL on Facebook:
```
example.org/news/entry/the-news-alias.html
```
Assume that the page `example.org/news.html` has a social image set in the page properties. Now, since the news teaser image is only appended to the `$GLOBALS['SOCIAL_IMAGES']` and the social image from the page [is always prepended](https://github.com/codefog/contao-social_images/blob/3.2.0/classes/SocialImages.php#L88), the social page image will always appear before any other image.
```html
<meta property="og:image" content="http://example.org/files/social_image_from_page.jpg">
<meta property="og:image" content="http://example.org/files/news_teaser_image.jpg">
<meta property="og:image" content="http://example.org/files/content_element_image.jpg">
```
However, wouldn't it make more sense, that on this specific URL, you want to primarily share the _news teaser image_ rather than the social page image from the news reader page (`news/entry.html` in this case) or any of its parents (e.g. `news.html` in this case)?

The change in this pull request simply puts the news teaser image always in front of the array. This (currently) _ensures_ that the news teaser image always comes first (unless any other extension also pushes an image to the front of the array, after the news images have been pushed).

The social page image is also pushed to the front of the array, however this is done in the `getPageLayout` hook, which will always execute before the `parseArticles` hook. Thus, when the `parseArticles` hook is executed, the news teaser image are pushed in front of the already present social images of the news reader page (or its parents).
```html
<meta property="og:image" content="http://example.org/files/news_teaser_image.jpg">
<meta property="og:image" content="http://example.org/files/social_image_from_page.jpg">
<meta property="og:image" content="http://example.org/files/content_element_image.jpg">
```
Using semantic versioning this can probably be only released in `4.0.0` or higher.