### PR TITLE
convert spaces to %20

### DIFF
--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -89,7 +89,7 @@ class SocialImages extends \Controller
             $url = (\Environment::get('ssl') ? 'https://' : 'http://') . $url;
         }
 
-        return rtrim($url, '/') . '/' . $image;
+        return rtrim($url, '/') . '/' . str_replace(' ', '%20', $image);
     }
 
 

--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -89,7 +89,7 @@ class SocialImages extends \Controller
             $url = (\Environment::get('ssl') ? 'https://' : 'http://') . $url;
         }
 
-        return rtrim($url, '/') . '/' . str_replace(' ', '%20', $image);
+        return rtrim($url, '/') . '/' . \System::urlEncode($image);
     }
 
 


### PR DESCRIPTION
If you use image files with spaces in your news articles or as social images in general, Facebook will ignore those images.
```
URL 'http://example.org/files/content/some image with spaces.jpg' for property 
'og:image:url' of the object at 'http://example.org/foo.html' is invalid because it 
contains whitespace characters.
```
Since Contao does not automatically normalize file names after upload (and since it's difficult to school editors to _not_ use special characters in their file names...), I think it's helpful to at least convert the spaces to `%20` before using them as the `og:image`.