### PR TITLE
update composer.json so that packagist updates the package again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "social_images extension for Contao Open Source CMS",
     "keywords": ["contao", "social", "images"],
     "type": "contao-module",
-    "license": "LGPL-3.0+",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "Codefog",


### PR DESCRIPTION
Currently Packagist is not auto updating this package, because its `composer.json` is not approved by Packagist. See https://packagist.org/packages/codefog/contao-social_images - the 3.5.0 tag is missing for example.

Packagist now disallows the deprecated usage of `LGPL-3.0+` for the `license`. Instead you have to use `LGPL-3.0-or-later`.

This is pretty ridiculous of packagist to be honest. I suspect there are many, many packages that now aren't auto updated anymore, since they use `LGPL-3.0+`. I have to update a lot of my packages too -_-