### PR TITLE
decode image path before getimagesize

### DIFF
--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -59,7 +59,7 @@ class SocialImages extends \Controller
             // Resize the image
             if ($resize[0] || $resize[1] || $resize[2]) {
                 $strImage = \Image::get($strImage, $resize[0], $resize[1], $resize[2]);
-                list($width, $height) = getimagesize(TL_ROOT . '/' . $strImage);
+                list($width, $height) = getimagesize(TL_ROOT . '/' . urldecode($strImage));
             }
 
             $tagEnd = ($objPage->outputFormat === 'xhtml') ? ' />' : '>';


### PR DESCRIPTION
If the path to an image has spaces or other special characters in it, you will see the following warning:
```
Warning: getimagesize(files/dts/Death_to_stock_photography_weekend_work%20%283%20of%2010%29.jpg): failed to open stream: 
No such file or directory in vendor/codefog/contao-social_images/classes/SocialImages.php on line 62