### PR TITLE
use options_callback for image sizes

### DIFF
--- a/dca/tl_layout.php
+++ b/dca/tl_layout.php
@@ -55,7 +55,7 @@ $GLOBALS['TL_DCA']['tl_layout']['fields']['socialImages_resize'] = array
 	'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['socialImages_resize'],
     'exclude'                 => true,
     'inputType'               => 'imageSize',
-    'options'                 => System::getImageSizes(),
+    'options_callback'        => function() { System::getImageSizes(); },
     'reference'               => &$GLOBALS['TL_LANG']['MSC'],
     'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'),
     'sql'                     => "varchar(64) NOT NULL default ''"

--- a/dca/tl_layout.php
+++ b/dca/tl_layout.php
@@ -55,7 +55,7 @@ $GLOBALS['TL_DCA']['tl_layout']['fields']['socialImages_resize'] = array
 	'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['socialImages_resize'],
     'exclude'                 => true,
     'inputType'               => 'imageSize',
-    'options_callback'        => function() { System::getImageSizes(); },
+    'options_callback'        => function() { return System::getImageSizes(); },
     'reference'               => &$GLOBALS['TL_LANG']['MSC'],
     'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'),
     'sql'                     => "varchar(64) NOT NULL default ''"


### PR DESCRIPTION
Options that are retrieved from the database (including `System::getImageSizes()`) should always be retrieved with an `options_callback`, otherwise you might get the following error in the Install Tool, if not all tables are set up yet:
```
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'xxx.tl_image_size' doesn't exist
```