### PR TITLE
do not add images of events from the event menu

### DIFF
--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -402,6 +402,11 @@ class SocialImages extends \Controller
      */
     public function collectEventImages($arrEvents, $arrCalendars, $intStart, $intEnd, $objModule)
     {
+        // do not add images of events from the event menu
+        if ($objModule->type === 'eventmenu') {
+            return $arrEvents;
+        }
+
         if (!is_array($GLOBALS['SOCIAL_IMAGES'])) {
             return $arrEvents;
         }


### PR DESCRIPTION
If you use the event menu module, the images from _all_ events will be added to `$GLOBALS['SOCIAL_IMAGES']` on every page where the module is integrated. This is not desirable, as it will assign `og:image` tags of events to those pages that do not otherwise have any other social image defined.