### PR TITLE
Add support for event reader

### DIFF
--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -455,7 +455,7 @@ class SocialImages extends \Controller
     {
         if (!is_array($GLOBALS['SOCIAL_IMAGES']))
         {
-            return;
+            return $strBuffer;
         }
 
         if (!$objElement instanceof \ContentModule)

--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -453,12 +453,7 @@ class SocialImages extends \Controller
      */
     public function collectEventReaderImage($objContentModel, $strBuffer, $objElement)
     {
-        if (!is_array($GLOBALS['SOCIAL_IMAGES']))
-        {
-            return $strBuffer;
-        }
-
-        if (!$objElement instanceof \ContentModule)
+        if (!is_array($GLOBALS['SOCIAL_IMAGES']) || !$objElement instanceof \ContentModule)
         {
             return $strBuffer;
         }

--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -455,7 +455,7 @@ class SocialImages extends \Controller
             return;
         }
 
-        $strItem = \Input::get(\Config::get('useAutoItem') ? 'auto_item' : 'events');
+        $strItem = \Input::get(\Config::get('useAutoItem') ? 'auto_item' : 'events', false, true);
 
         if (empty($strItem))
         {

--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -455,7 +455,7 @@ class SocialImages extends \Controller
             return;
         }
 
-        $strItem = \Input::get(\Config::get('useAutoItem') ? 'auto_item' : 'item');
+        $strItem = \Input::get(\Config::get('useAutoItem') ? 'auto_item' : 'events');
 
         if (empty($strItem))
         {

--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -446,37 +446,27 @@ class SocialImages extends \Controller
 
     /**
      * Collect the image from the currently displayed event
-     * @param \ContentModel
-     * @param string
-     * @param \ContentElement
-     * @return string
+     * @param \Template
      */
-    public function collectEventReaderImage($objContentModel, $strBuffer, $objElement)
+    public function collectEventReaderImage($objTemplate)
     {
-        if (!is_array($GLOBALS['SOCIAL_IMAGES']) || !$objElement instanceof \ContentModule)
+        if (!is_array($GLOBALS['SOCIAL_IMAGES']) || 0 !== strpos($objTemplate->getName(), 'mod_eventreader'))
         {
-            return $strBuffer;
+            return;
         }
 
         $strItem = \Input::get(\Config::get('useAutoItem') ? 'auto_item' : 'item');
 
         if (empty($strItem))
         {
-            return $strBuffer;
-        }
-
-        $objModuleModel = \ModuleModel::findByPk($objContentModel->module);
-
-        if ('eventreader' !== $objModuleModel->type && 'eventlist' === $objModuleModel->type && empty($objModuleModel->cal_readerModule))
-        {
-            return $strBuffer;
+            return;
         }
 
         $objEvent = \CalendarEventsModel::findByIdOrAlias($strItem);
 
         if (null === $objEvent)
         {
-            return $strBuffer;
+            return;
         }
 
         $objFile = \FilesModel::findById($objEvent->singleSRC);
@@ -485,7 +475,5 @@ class SocialImages extends \Controller
         {
             array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
         }
-
-        return $strBuffer;
     }
 }

--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -442,4 +442,55 @@ class SocialImages extends \Controller
 
         return $arrEvents;
     }
+
+
+    /**
+     * Collect the image from the currently displayed event
+     * @param \ContentModel
+     * @param string
+     * @param \ContentElement
+     * @return string
+     */
+    public function collectEventReaderImage($objContentModel, $strBuffer, $objElement)
+    {
+        if (!is_array($GLOBALS['SOCIAL_IMAGES']))
+        {
+            return;
+        }
+
+        if (!$objElement instanceof \ContentModule)
+        {
+            return $strBuffer;
+        }
+
+        $strItem = \Input::get(\Config::get('useAutoItem') ? 'auto_item' : 'item');
+
+        if (empty($strItem))
+        {
+            return $strBuffer;
+        }
+
+        $objModuleModel = \ModuleModel::findByPk($objContentModel->module);
+
+        if ('eventreader' !== $objModuleModel->type && 'eventlist' === $objModuleModel->type && empty($objModuleModel->cal_readerModule))
+        {
+            return $strBuffer;
+        }
+
+        $objEvent = \CalendarEventsModel::findByIdOrAlias($strItem);
+
+        if (null === $objEvent)
+        {
+            return $strBuffer;
+        }
+
+        $objFile = \FilesModel::findById($objEvent->singleSRC);
+
+        if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
+        {
+            array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
+        }
+
+        return $strBuffer;
+    }
 }

--- a/config/config.php
+++ b/config/config.php
@@ -33,4 +33,4 @@ $GLOBALS['TL_HOOKS']['getContentElement'][] = array('SocialImages', 'collectCont
 $GLOBALS['TL_HOOKS']['generatePage'][] = array('SocialImages', 'addSocialImages');
 $GLOBALS['TL_HOOKS']['parseArticles'][] = array('SocialImages', 'collectNewsImages');
 $GLOBALS['TL_HOOKS']['getPageLayout'][] = array('SocialImages', 'collectPageImages');
-$GLOBALS['TL_HOOKS']['getContentElement'][] = array('SocialImages', 'collectEventReaderImage');
+$GLOBALS['TL_HOOKS']['parseTemplate'][] = array('SocialImages', 'collectEventReaderImage');

--- a/config/config.php
+++ b/config/config.php
@@ -33,3 +33,4 @@ $GLOBALS['TL_HOOKS']['getContentElement'][] = array('SocialImages', 'collectCont
 $GLOBALS['TL_HOOKS']['generatePage'][] = array('SocialImages', 'addSocialImages');
 $GLOBALS['TL_HOOKS']['parseArticles'][] = array('SocialImages', 'collectNewsImages');
 $GLOBALS['TL_HOOKS']['getPageLayout'][] = array('SocialImages', 'collectPageImages');
+$GLOBALS['TL_HOOKS']['getContentElement'][] = array('SocialImages', 'collectEventReaderImage');


### PR DESCRIPTION
Currently the extension collects images from events only via the `getAllEvents` hook. However, that hooks isn't actually executed on the detail page of an event. Thus there will be no `og:image` URL of an event.

This PR implements support for the event reader image by implementing a `getContentElement` hook. The hook checks whether this is the event detail page via various variables, i.e. the presence of an item and whether the content element is a module content element that includes either a event reader module directly or an event list module with a reader module defined.