### PR TITLE
Allow definition of specific social image for news and events

### DIFF
--- a/classes/SocialImages.php
+++ b/classes/SocialImages.php
@@ -374,23 +374,30 @@ class SocialImages extends \Controller
      */
     public function collectNewsImages($objTemplate, $arrData, $objModule)
     {
-        if (!is_array($GLOBALS['SOCIAL_IMAGES']) || !$arrData['addImage'])
+        if (!is_array($GLOBALS['SOCIAL_IMAGES']))
         {
             return;
         }
 
-        $objFile = \FilesModel::findByPk($arrData['singleSRC']);
+        $strSocialImage = $this->getFilePath($arrData['socialImage']);
 
-        if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
+        if ($strSocialImage === null && $arrData['addImage'])
         {
-            if ($objModule->type === 'newsreader')
-            {
-                array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
-            }
-            else
-            {
-                $GLOBALS['SOCIAL_IMAGES'][] = $objFile->path;
-            }
+            $strSocialImage = $this->getFilePath($arrData['singleSRC']);
+        }
+
+        if ($strSocialImage === null)
+        {
+            return;
+        }
+
+        if ($objModule->type === 'newsreader')
+        {
+            array_unshift($GLOBALS['SOCIAL_IMAGES'], $strSocialImage);
+        }
+        else
+        {
+            $GLOBALS['SOCIAL_IMAGES'][] = $strSocialImage;
         }
     }
 
@@ -417,25 +424,26 @@ class SocialImages extends \Controller
             {
                 foreach ($vv as $arrData)
                 {
-                    if (!$arrData['addImage'])
+                    $strSocialImage = $this->getFilePath($arrData['socialImage']);
+
+                    if ($strSocialImage === null && $arrData['addImage'])
                     {
-                        return $arrEvents;
+                        $strSocialImage = $this->getFilePath($arrData['singleSRC']);
                     }
 
-                    $objFile = \FilesModel::findByPk($arrData['singleSRC']);
-
-                    if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
+                    if ($strSocialImage === null)
                     {
-                        if ($objModule->type === 'eventreader')
-                        {
-                            array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
-                        }
-                        else
-                        {
-                            $GLOBALS['SOCIAL_IMAGES'][] = $objFile->path;
-                        }
+                        continue;
                     }
 
+                    if ($objModule->type === 'eventreader')
+                    {
+                        array_unshift($GLOBALS['SOCIAL_IMAGES'], $strSocialImage);
+                    }
+                    else
+                    {
+                        $GLOBALS['SOCIAL_IMAGES'][] = $strSocialImage;
+                    }
                 }
             }
         }
@@ -469,11 +477,36 @@ class SocialImages extends \Controller
             return;
         }
 
-        $objFile = \FilesModel::findById($objEvent->singleSRC);
+        $strSocialImage = $this->getFilePath($objEvent->socialImage);
 
-        if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
+        if ($strSocialImage === null && $objEvent->addImage)
         {
-            array_unshift($GLOBALS['SOCIAL_IMAGES'], $objFile->path);
+            $strSocialImage = $this->getFilePath($objEvent->singleSRC);
         }
+
+        if ($strSocialImage === null)
+        {
+            return;
+        }
+
+        array_unshift($GLOBALS['SOCIAL_IMAGES'], $strSocialImage);
+    }
+
+
+    /**
+     * Returns the file path for a given ID/UUID. Returns null if the file does not exist anymore.
+     * @param string
+     * @return string|null
+     */
+    private function getFilePath($strFileId)
+    {
+        $objFile = \FilesModel::findById($strFileId);
+
+        if ($objFile === null || !is_file(TL_ROOT . '/' . $objFile->path))
+        {
+            return null;
+        }
+
+        return $objFile->path;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "contao/core-bundle": "~3.2 || ~4.0",
+        "contao/core-bundle": "^4.4",
         "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
     },
     "extra": {

--- a/dca/tl_calendar_events.php
+++ b/dca/tl_calendar_events.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Extend tl_calendar_events palettes
+ */
+foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['palettes'] as $k=>$v)
+{
+    if (!\is_string($v))
+    {
+        continue;
+    }
+
+	$GLOBALS['TL_DCA']['tl_calendar_events']['palettes'][$k] = str_replace('{expert_legend', '{socialimages_legend:hide},socialImage;{expert_legend', $v);
+}
+
+
+/**
+ * Add the field to tl_calendar_events
+ */
+$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['socialImage'] = array
+(
+	'label'                   => &$GLOBALS['TL_LANG']['tl_calendar_events']['socialImage'],
+	'exclude'                 => true,
+	'inputType'               => 'fileTree',
+	'eval'                    => array('files'=>true, 'filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>$GLOBALS['TL_CONFIG']['validImageTypes'], 'tl_class'=>'clr'),
+	'sql'                     => "binary(16) NULL"
+);

--- a/dca/tl_calendar_events.php
+++ b/dca/tl_calendar_events.php
@@ -12,17 +12,24 @@
  */
 
 
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+
 /**
  * Extend tl_calendar_events palettes
  */
 foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['palettes'] as $k=>$v)
 {
-    if (!\is_string($v))
-    {
-        continue;
-    }
+	if (!\is_string($v))
+	{
+		continue;
+	}
 
-	$GLOBALS['TL_DCA']['tl_calendar_events']['palettes'][$k] = str_replace('{expert_legend', '{socialimages_legend:hide},socialImage;{expert_legend', $v);
+	PaletteManipulator::create()
+		->addLegend('socialimages_legend', 'expert_legend', PaletteManipulator::POSITION_BEFORE, true)
+		->addField('socialImage', 'socialimages_legend', PaletteManipulator::POSITION_APPEND)
+		->applyToPalette($k, 'tl_calendar_events')
+	;
 }
 
 

--- a/dca/tl_news.php
+++ b/dca/tl_news.php
@@ -12,17 +12,24 @@
  */
 
 
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+
 /**
  * Extend tl_news palettes
  */
 foreach ($GLOBALS['TL_DCA']['tl_news']['palettes'] as $k=>$v)
 {
-    if (!\is_string($v))
-    {
-        continue;
-    }
+	if (!\is_string($v))
+	{
+		continue;
+	}
 
-	$GLOBALS['TL_DCA']['tl_news']['palettes'][$k] = str_replace('{expert_legend', '{socialimages_legend:hide},socialImage;{expert_legend', $v);
+	PaletteManipulator::create()
+		->addLegend('socialimages_legend', 'expert_legend', PaletteManipulator::POSITION_BEFORE, true)
+		->addField('socialImage', 'socialimages_legend', PaletteManipulator::POSITION_APPEND)
+		->applyToPalette($k, 'tl_news')
+	;
 }
 
 

--- a/dca/tl_news.php
+++ b/dca/tl_news.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Extend tl_news palettes
+ */
+foreach ($GLOBALS['TL_DCA']['tl_news']['palettes'] as $k=>$v)
+{
+    if (!\is_string($v))
+    {
+        continue;
+    }
+
+	$GLOBALS['TL_DCA']['tl_news']['palettes'][$k] = str_replace('{expert_legend', '{socialimages_legend:hide},socialImage;{expert_legend', $v);
+}
+
+
+/**
+ * Add the field to tl_news
+ */
+$GLOBALS['TL_DCA']['tl_news']['fields']['socialImage'] = array
+(
+	'label'                   => &$GLOBALS['TL_LANG']['tl_news']['socialImage'],
+	'exclude'                 => true,
+	'inputType'               => 'fileTree',
+	'eval'                    => array('files'=>true, 'filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>$GLOBALS['TL_CONFIG']['validImageTypes'], 'tl_class'=>'clr'),
+	'sql'                     => "binary(16) NULL"
+);

--- a/languages/de/tl_calendar_events.php
+++ b/languages/de/tl_calendar_events.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_calendar_events']['socialImage'] = array('Social Images', 'Hier kann man das Social Image für dieses Event festlegen, welches statt dem Teaser-Bild benutzt wird.');
+
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_calendar_events']['socialimages_legend'] = 'Social Images';

--- a/languages/de/tl_news.php
+++ b/languages/de/tl_news.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_news']['socialImage'] = array('Social Images', 'Hier kann man das Social Image für diese Nachricht festlegen, welches statt dem Teaser-Bild benutzt wird.');
+
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_news']['socialimages_legend'] = 'Social Images';

--- a/languages/en/tl_calendar_events.php
+++ b/languages/en/tl_calendar_events.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_calendar_events']['socialImage'] = array('Social image', 'Here you can define a social image that will be used instead of the teaser image.');
+
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_calendar_events']['socialimages_legend'] = 'Social Images';

--- a/languages/en/tl_news.php
+++ b/languages/en/tl_news.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_news']['socialImage'] = array('Social image', 'Here you can define a social image that will be used instead of the teaser image.');
+
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_news']['socialimages_legend'] = 'Social Images';

--- a/languages/it/tl_calendar_events.php
+++ b/languages/it/tl_calendar_events.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_calendar_events']['socialimages_legend'] = 'Immagini social';

--- a/languages/it/tl_news.php
+++ b/languages/it/tl_news.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_news']['socialimages_legend'] = 'Immagini social';

--- a/languages/pl/tl_calendar_events.php
+++ b/languages/pl/tl_calendar_events.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_calendar_events']['socialimages_legend'] = 'Obrazki społecznościowe';

--- a/languages/pl/tl_news.php
+++ b/languages/pl/tl_news.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * social_images extension for Contao Open Source CMS
+ *
+ * Copyright (C) 2013 Codefog
+ *
+ * @package social_images
+ * @author  Codefog <http://codefog.pl>
+ * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
+ * @license LGPL
+ */
+
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_news']['socialimages_legend'] = 'Obrazki społecznościowe';


### PR DESCRIPTION
Our customers often want to define a specific image for sharing on social networks that is different from the teaser image of the news or event (as it might be a different image altogether or include additional text etc.).

This PR allows to set a specific social image for news and events which will then be used instead of the teaser image.

Polish and Italian translation missing though.