### PR TITLE
Fix soft dependencies

### DIFF
--- a/config/autoload.ini
+++ b/config/autoload.ini
@@ -2,6 +2,8 @@
 ; List modules which are required to be loaded beforehand
 ;;
 requires[] = "core"
+requires[] = "*news"
+requires[] = "*calendar"
 
 ;;
 ; Configure what you want the autoload creator to register

--- a/dca/tl_calendar_events.php
+++ b/dca/tl_calendar_events.php
@@ -18,18 +18,21 @@ use Contao\CoreBundle\DataContainer\PaletteManipulator;
 /**
  * Extend tl_calendar_events palettes
  */
-foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['palettes'] as $k=>$v)
+if (!empty($GLOBALS['TL_DCA']['tl_calendar_events']['palettes']))
 {
-	if (!\is_string($v))
+	foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['palettes'] as $k=>$v)
 	{
-		continue;
-	}
+		if (!\is_string($v))
+		{
+			continue;
+		}
 
-	PaletteManipulator::create()
-		->addLegend('socialimages_legend', 'expert_legend', PaletteManipulator::POSITION_BEFORE, true)
-		->addField('socialImage', 'socialimages_legend', PaletteManipulator::POSITION_APPEND)
-		->applyToPalette($k, 'tl_calendar_events')
-	;
+		PaletteManipulator::create()
+			->addLegend('socialimages_legend', 'expert_legend', PaletteManipulator::POSITION_BEFORE, true)
+			->addField('socialImage', 'socialimages_legend', PaletteManipulator::POSITION_APPEND)
+			->applyToPalette($k, 'tl_calendar_events')
+		;
+	}
 }
 
 

--- a/dca/tl_calendar_events.php
+++ b/dca/tl_calendar_events.php
@@ -39,11 +39,14 @@ if (!empty($GLOBALS['TL_DCA']['tl_calendar_events']['palettes']))
 /**
  * Add the field to tl_calendar_events
  */
-$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['socialImage'] = array
-(
-	'label'                   => &$GLOBALS['TL_LANG']['tl_calendar_events']['socialImage'],
-	'exclude'                 => true,
-	'inputType'               => 'fileTree',
-	'eval'                    => array('files'=>true, 'filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>$GLOBALS['TL_CONFIG']['validImageTypes'], 'tl_class'=>'clr'),
-	'sql'                     => "binary(16) NULL"
-);
+if (!empty($GLOBALS['TL_DCA']['tl_calendar_events']['fields']))
+{
+	$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['socialImage'] = array
+	(
+		'label'                   => &$GLOBALS['TL_LANG']['tl_calendar_events']['socialImage'],
+		'exclude'                 => true,
+		'inputType'               => 'fileTree',
+		'eval'                    => array('files'=>true, 'filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>$GLOBALS['TL_CONFIG']['validImageTypes'], 'tl_class'=>'clr'),
+		'sql'                     => "binary(16) NULL"
+	);
+}

--- a/dca/tl_news.php
+++ b/dca/tl_news.php
@@ -39,11 +39,14 @@ if (!empty($GLOBALS['TL_DCA']['tl_news']['palettes']))
 /**
  * Add the field to tl_news
  */
-$GLOBALS['TL_DCA']['tl_news']['fields']['socialImage'] = array
-(
-	'label'                   => &$GLOBALS['TL_LANG']['tl_news']['socialImage'],
-	'exclude'                 => true,
-	'inputType'               => 'fileTree',
-	'eval'                    => array('files'=>true, 'filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>$GLOBALS['TL_CONFIG']['validImageTypes'], 'tl_class'=>'clr'),
-	'sql'                     => "binary(16) NULL"
-);
+if (!empty($GLOBALS['TL_DCA']['tl_news']['fields']))
+{
+	$GLOBALS['TL_DCA']['tl_news']['fields']['socialImage'] = array
+	(
+		'label'                   => &$GLOBALS['TL_LANG']['tl_news']['socialImage'],
+		'exclude'                 => true,
+		'inputType'               => 'fileTree',
+		'eval'                    => array('files'=>true, 'filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>$GLOBALS['TL_CONFIG']['validImageTypes'], 'tl_class'=>'clr'),
+		'sql'                     => "binary(16) NULL"
+	);
+}

--- a/dca/tl_news.php
+++ b/dca/tl_news.php
@@ -18,18 +18,21 @@ use Contao\CoreBundle\DataContainer\PaletteManipulator;
 /**
  * Extend tl_news palettes
  */
-foreach ($GLOBALS['TL_DCA']['tl_news']['palettes'] as $k=>$v)
+if (!empty($GLOBALS['TL_DCA']['tl_news']['palettes']))
 {
-	if (!\is_string($v))
+	foreach ($GLOBALS['TL_DCA']['tl_news']['palettes'] as $k=>$v)
 	{
-		continue;
-	}
+		if (!\is_string($v))
+		{
+			continue;
+		}
 
-	PaletteManipulator::create()
-		->addLegend('socialimages_legend', 'expert_legend', PaletteManipulator::POSITION_BEFORE, true)
-		->addField('socialImage', 'socialimages_legend', PaletteManipulator::POSITION_APPEND)
-		->applyToPalette($k, 'tl_news')
-	;
+		PaletteManipulator::create()
+			->addLegend('socialimages_legend', 'expert_legend', PaletteManipulator::POSITION_BEFORE, true)
+			->addField('socialImage', 'socialimages_legend', PaletteManipulator::POSITION_APPEND)
+			->applyToPalette($k, 'tl_news')
+		;
+	}
 }
 
 


### PR DESCRIPTION
There was an oversight in my last PR - it did not take setups into account were either `contao/news-bundle` or `contao/calendar-bundle` (or both) are not installed. This updates the soft dependencies and also includes a check for whether the respective DCA actually exists.