### PR TITLE
Use Symfony Path instead of Webmozart

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "contao/core-bundle": "^4.13"
+        "contao/core-bundle": "^4.13",
+        "symfony/filesystem": "^5.4 || ^6.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",

--- a/src/ImageGenerator.php
+++ b/src/ImageGenerator.php
@@ -20,7 +20,7 @@ use Contao\File;
 use Contao\PageModel;
 use Contao\StringUtil;
 use Contao\System;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class ImageGenerator
 {


### PR DESCRIPTION
Webmozart\PathUtil was dropped in Contao 4.13 and currently generates an error