### PR TITLE
Fix PHP 8 error in ImageGenerator

### DIFF
--- a/src/ImageGenerator.php
+++ b/src/ImageGenerator.php
@@ -51,7 +51,7 @@ class ImageGenerator
 
         // Limit the images
         if ($settings['limit'] > 0) {
-            $images = \array_slice($images, 0, $settings['limit']);
+            $images = \array_slice($images, 0, (int) $settings['limit']);
         }
 
         $return = [];


### PR DESCRIPTION
This fixes the following error:

```
Uncaught PHP Exception TypeError: "array_slice(): Argument #3 ($length) must be of type ?int, string given" at vendor/codefog/contao-social_images/src/ImageGenerator.php line 54
```