### PR TITLE
Limit after processing the images

### DIFF
--- a/src/ImageGenerator.php
+++ b/src/ImageGenerator.php
@@ -51,12 +51,6 @@ class ImageGenerator
 
         $settings['size'] = StringUtil::deserialize($settings['size']);
         $settings['resize'] = StringUtil::deserialize($settings['resize']);
-
-        // Limit the images
-        if ($settings['limit'] > 0) {
-            $images = \array_slice($images, 0, (int) $settings['limit']);
-        }
-
         $return = [];
 
         foreach ($images as $image) {
@@ -80,6 +74,11 @@ class ImageGenerator
                 'type' => self::TYPE_LOCAL,
                 'file' => $this->resizeImage($file, $settings),
             ];
+        }
+
+        // Limit the images
+        if ($settings['limit'] > 0) {
+            $return = \array_slice($return, 0, (int) $settings['limit']);
         }
 
         return $return;


### PR DESCRIPTION
Currently the `limit` is applied _before_ processing the images. This means if you for example have 3 candidates and they are limited to 1 - and that candidate is then discarded because of its size for example, you end up with no images - even though the next candidate would fulfil the requirements.

It would be a behavior change though. @qzminski wdyt?