### PR TITLE
Unlock Symfony 7 & 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "contao/core-bundle": "^4.13 || ^5.3",
-        "symfony/filesystem": "^5.4 || ^6.0"
+        "symfony/filesystem": "^5.4 || ^6.4 || ^7.4 || ^8.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",


### PR DESCRIPTION
This unlocks Symfony 7 & 8 (required for Contao 5.7).